### PR TITLE
Babelify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist
 node_modules
 npm-debug.log
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-dist
-node_modules
-npm-debug.log
+/coverage
+/dist
+/node_modules
 .DS_Store
 .*.swp
-yarn.lock
-coverage
 .nyc_output
 coverage.lcov
+npm-debug.log
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "ava": "^0.19.1",
+    "babel-cli": "^6.24.1",
+    "babel-preset-env": "^1.4.0",
     "codecov": "^2.1.0",
     "eslint": "~3.19.0",
     "eslint-config-airbnb": "~14.1.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "dist"
   ],
   "scripts": {
+    "build": "babel src --presets env --out-dir dist",
     "lint": "eslint src/**/*.js",
-    "prepublish": "babel src --presets env --out-dir dist",
+    "prepublish": "npm run build",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
-    "test": "npm run lint && npm run test:only",
+    "test": "npm run build && npm run lint && npm run test:only",
     "test:only": "nyc ava",
     "test:dev": "ava --watch"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "redux-promise-actions",
   "version": "0.5.1",
   "description": "Flux Standard Action async utilities for Redux.",
-  "main": "index.js",
+  "main": "dist",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src/**/*.js",
+    "prepublish": "babel src --presets env --out-dir dist",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "test": "npm run lint && npm run test:only",
     "test:only": "nyc ava",

--- a/src/__tests__/module.js
+++ b/src/__tests__/module.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import module from '../../index';
+import module from '../';
 
 test('exports middleware', t => t.is(typeof module.middleware, 'function'));
 test('exports handlePromiseAction', t => t.is(typeof module.handlePromiseAction, 'function'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-const middleware = require('./src/middleware');
-const handlePromiseAction = require('./src/handlePromiseAction');
-const helpers = require('./src/helpers');
+const middleware = require('./middleware');
+const handlePromiseAction = require('./handlePromiseAction');
+const helpers = require('./helpers');
 
 module.exports = {
   middleware,


### PR DESCRIPTION
Babelifying the module to extend compability, with for example `uglify`, which is extra needed when `engine` isn't defined